### PR TITLE
Fix GUI browse button binding

### DIFF
--- a/BBPRO98-GUI.ps1
+++ b/BBPRO98-GUI.ps1
@@ -81,9 +81,10 @@ function Set-Inputs {
         $btn.Location = [Drawing.Point]::new(500, ($i * 30) - 1)
         $btn.Size = New-Object Drawing.Size(70,23)
         $btn.Text = 'Browse'
+        $btn.Tag = $txt
         $btn.Add_Click({
             $dlg = New-Object Windows.Forms.OpenFileDialog
-            if ($dlg.ShowDialog() -eq 'OK') { $txt.Text = $dlg.FileName }
+            if ($dlg.ShowDialog() -eq 'OK') { $this.Tag.Text = $dlg.FileName }
         })
         $pnlInputs.Controls.Add($btn)
     }


### PR DESCRIPTION
## Summary
- Ensure GUI browse buttons fill their associated text boxes

## Testing
- `pwsh -NoLogo -NoProfile -File BBPRO98-GUI.ps1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae99dc5840832ebf246339f56c7838