### PR TITLE
feat: add powershell fallback

### DIFF
--- a/BBPRO98-GUI.ps1
+++ b/BBPRO98-GUI.ps1
@@ -102,7 +102,13 @@ $btnRun.Add_Click({
     $sel = $scriptDefinitions | Where-Object { $_.Name -eq $combo.SelectedItem }
     if (-not $sel) { return }
     $psi = New-Object Diagnostics.ProcessStartInfo
-    $psi.FileName = 'pwsh'
+    # Use PowerShell Core if available, otherwise fall back to Windows PowerShell
+    $psCmd = Get-Command pwsh -ErrorAction SilentlyContinue
+    if ($psCmd) {
+        $psi.FileName = $psCmd.Source
+    } else {
+        $psi.FileName = (Get-Command powershell).Source
+    }
     $psi.Arguments = "-ExecutionPolicy Bypass -File `"$($sel.File)`""
     $psi.UseShellExecute = $false
     $psi.RedirectStandardInput = $true


### PR DESCRIPTION
## Summary
- detect installed PowerShell and fall back to `powershell` when `pwsh` is unavailable

## Testing
- `pwsh -NoLogo -Command "$PSVersionTable.PSVersion"` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403 forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ae9bd8aaa0832ea05a39da42bae32a