### PR TITLE
Support output path for ASN extractor

### DIFF
--- a/ASN-Extractor-B.ps1
+++ b/ASN-Extractor-B.ps1
@@ -1,7 +1,8 @@
 # This will Extract parts of ASN
 param(
     [Parameter(ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
-    [string]$ASNFile
+    [string]$ASNFile,
+    [string]$OutputDir
 )
 
 $ErrorActionPreference = 'Stop'
@@ -27,8 +28,15 @@ if (-not (Test-Path $ASNFile)) {
     exit 1
 }
 
+$OutputDir = $OutputDir -replace '"',''
+if ($OutputDir) {
+    $BaseOut = $OutputDir
+} else {
+    $BaseOut = $ScriptPath
+}
+
 $LeagueName = (Get-Item $ASNFile).BaseName
-$OutputDir = Join-Path $ScriptPath $LeagueName
+$OutputDir = Join-Path $BaseOut $LeagueName
 if (-not (Test-Path $OutputDir)) {
     New-Item -ItemType Directory -Path $OutputDir | Out-Null
 }

--- a/BBPRO98-GUI.ps1
+++ b/BBPRO98-GUI.ps1
@@ -118,6 +118,9 @@ $btnRun.Add_Click({
         $psi.FileName = (Get-Command powershell).Source
     }
     $psi.Arguments = "-ExecutionPolicy Bypass -File `"$($sel.File)`""
+    if ($txtOut.Text -and $sel.Name -eq 'ASN-Extractor-B') {
+        $psi.Arguments += " -OutputDir `"$($txtOut.Text)`""
+    }
     $psi.UseShellExecute = $false
     $psi.RedirectStandardInput = $true
     $psi.RedirectStandardOutput = $true

--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ Refined extractor that accepts file paths as parameters, sanitizes input, create
 **Usage**
 
 ```powershell
-pwsh ./ASN-Extractor-B.ps1
+pwsh ./ASN-Extractor-B.ps1 [-OutputDir <folder>]
 ```
 
-Provide the path to the `.ASN` file when prompted. The tool writes per-team CSV files and a consolidated roster to a new folder named after the league file.
+Provide the path to the `.ASN` file when prompted. The tool writes per-team CSV files and a consolidated roster to a new folder named after the league file. If `-OutputDir` is supplied (or an output folder is selected in the GUI), that folder is used as the base path for the league folder; otherwise the script's directory is used.
 
 ### `ASN-Importer-A.ps1`
 Imports edited roster CSVs back into an `.ASN` file. Backs up the original, rebuilds encryption tables, rewrites roster slots, batting orders, defensive alignments, and pitcher rotations, and outputs the updated file.


### PR DESCRIPTION
## Summary
- allow ASN-Extractor-B to accept an optional output folder
- pass GUI-selected output folder to ASN-Extractor-B
- document new `-OutputDir` option

## Testing
- `pwsh ./ASN-Extractor-B.ps1 data_files/28DEV001.ASN -OutputDir /tmp/out` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed, 403)*

------
https://chatgpt.com/codex/tasks/task_e_68aea4628208832e81497c6f2201c608