### PR TITLE
Fix output path in ASN extractor

### DIFF
--- a/ASN-Extractor-B.ps1
+++ b/ASN-Extractor-B.ps1
@@ -226,10 +226,10 @@ foreach ($o in ($Offsets | ? {$_.Length -eq 274 } | select -skip 1))
 	
 }
 ""
-$TeamInfo = $TeamInfo | convertfrom-csv 
+$TeamInfo = $TeamInfo | convertfrom-csv
 $TeamInfo | ft
 
-$OutputFileName = "$ThePath\$LeagueName\$LeagueName-Team-Info.csv"
+$OutputFileName = Join-Path $OutputDir "$LeagueName-Team-Info.csv"
 $TeamInfo | Export-Csv -Path $OutputFileName -Force -notype
 
 


### PR DESCRIPTION
## Summary
- use validated `$OutputDir` when writing team info CSVs to avoid missing directory errors

## Testing
- `pwsh ./ASN-Extractor-B.ps1 -OutputDir test-output` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68aea5548b44832ebab4fbbd24f9b96c